### PR TITLE
Bugfix for temperature by liquid + some cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 
 build/
 .ccls-cache/
+compile_commands.json

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@
 *.app
 
 build/
+.ccls-cache/

--- a/config/levd.cfg
+++ b/config/levd.cfg
@@ -1,24 +1,25 @@
 ---
 conky_file: "/etc/leviathan/conky_levd.updates"
 main_color: 0x000000FF
-temperature_source: "cpu"
+temperature_source: "liquid"
 fan_profile:
   -
-    - 30
-    - 30
-  -
     - 35
+    - 30
+  -
+    - 36
+    - 35
+  -
+    - 37
     - 40
   -
-    - 40
+    - 38
+    - 50
+  -
+    - 39
     - 60
   -
-    - 42
-    - 70
-  -
-    - 43
-    - 80
-  -
-    - 45
+    - 40
     - 100
-interval: 500
+
+program_loop_interval_ms: 1000

--- a/constants.h
+++ b/constants.h
@@ -11,6 +11,8 @@
 #define KRAKEN_INIT 0x0002
 #define KRAKEN_BEGIN 0x0001
 
+#define DEFAULT_RED 0xFF0000
+
 const char *const kDefaultCPUTempFile = "/sys/class/hwmon/hwmon0/temp1_input";
 const char *const kDefaultConfigFile  = "/etc/leviathan/levd.cfg";
 const char *const kDefaultConkyFile  = "/etc/leviathan/levd.cfg";

--- a/cpu_temperature_monitor.hpp
+++ b/cpu_temperature_monitor.hpp
@@ -26,15 +26,25 @@ class CpuTemperatureMonitor {
     }
     return temperatureForCoreId(core_id + 1);
   }
+  // Takes an average across all cores, does not factor in package ID
+  double getAverageTempAcrossCores() const {
+    uint32_t runningTotal = 0;
+    for (uint8_t i = 1; i <= coreCount(); ++i)
+      runningTotal += temperatureForCoreId(i);
+    return runningTotal / coreCount();
+  }
+
   // Returns the number of physical cores in the CPU
   size_t coreCount() const { return subfeatures_.size() - 1; }
 
  private:
+
+  // NOTE: Remember the 0th item is PackageId
   uint32_t temperatureForCoreId(uint8_t id) const {
     const sensors_subfeature *const subfeature = subfeatures_[id];
     double                          value;
     if (sensors_get_value(cn_, subfeature->number, &value) != 0) {
-      LOG(WARNING) << "Failure on call to lmsensors::sensors_get_value()";
+      SYSLOG(WARNING) << "Failure on call to lmsensors::sensors_get_value()";
       return std::numeric_limits<int>::min();
     }
     return value;

--- a/kraken_driver.cpp
+++ b/kraken_driver.cpp
@@ -8,6 +8,7 @@
 #define kMainConfigurationIndex 0
 #define kMainConfigurationValue 1
 
+namespace levd {
 void set_color_arr(const uint32_t c, unsigned char *arr) {
   arr[0] = (c & 0x00FF0000) >> 16;
   arr[1] = (c & 0x0000FF00) >> 8;
@@ -114,7 +115,7 @@ std::map<std::string, uint32_t> KrakenDriver::receiveStatus() {
   unsigned char                   status[32];
   std::map<std::string, uint32_t> results;
   if (readBulkRawData(status, 32) == false) {
-    LOG(WARNING) << "Call to readBulkRawData - 32 bytes, failed";
+    SYSLOG(WARNING) << "Call to readBulkRawData - 32 bytes, failed";
     return results;
   }
   // TODO: Kraken is returning 0 for status[0] and status[1]
@@ -124,3 +125,4 @@ std::map<std::string, uint32_t> KrakenDriver::receiveStatus() {
   results["liquid_temperature"] = status[10];
   return results;
 }
+}  // namespace levd

--- a/kraken_driver.hpp
+++ b/kraken_driver.hpp
@@ -1,12 +1,11 @@
-#ifndef KRAKEN_DRIVER_H
-#define KRAKEN_DRIVER_H
-
+#pragma once
 #include <libusb-1.0/libusb.h>
 #include <map>
 #include <string>
 
 #include "constants.h"
 
+namespace levd {
 // Using this class will query usb bus for the kraken device details
 // and set the proper usb configuration to kMainConfigurationIndex
 class KrakenDriver {
@@ -15,13 +14,13 @@ class KrakenDriver {
   // Creating an instance of this object claims ownership of the usb
   // endpoint, new instances fail to initalize on construction
   KrakenDriver(libusb_device *kraken);
-  KrakenDriver(const KrakenDriver &) = delete;
+  KrakenDriver(const KrakenDriver &)  = delete;
   KrakenDriver(const KrakenDriver &&) = delete;
   virtual ~KrakenDriver();
 
-  void setFanSpeed(unsigned char);
-  void setPumpSpeed(unsigned char);
-  void setColor(uint32_t);
+  void                            setFanSpeed(unsigned char);
+  void                            setPumpSpeed(unsigned char);
+  void                            setColor(uint32_t);
   std::map<std::string, uint32_t> sendColorUpdate();
   std::map<std::string, uint32_t> sendSpeedUpdate();
 
@@ -48,5 +47,4 @@ class KrakenDriver {
   libusb_endpoint_descriptor _endpointOut;
   libusb_endpoint_descriptor _endpointIn;
 };
-
-#endif  // KRAKEN_DRIVER_H
+}  // namespace levd

--- a/leviathan_config.hpp
+++ b/leviathan_config.hpp
@@ -1,30 +1,21 @@
-#ifndef LEVIATHAN_CONFIG_H
-#define LEVIATHAN_CONFIG_H
-
+#pragma once
 #include "constants.h"
 #include <functional>
 #include <map>
 #include <string>
 
-#define DEFAULT_RED 0xFF0000
-
+namespace levd {
 using LineFunction = std::function<int32_t(int32_t)>;
 
-enum class TempSource { CPU, LIQUID };
+enum class TempSource { Cpu, Liquid };
 
 inline TempSource stringToTempSource(const std::string &tss) {
-  return tss == "liquid" ? TempSource::LIQUID : TempSource::CPU;
+  return tss == "cpu" ? TempSource::Cpu : TempSource::Liquid;
 }
-
-struct Point {
-  int32_t x;
-  int32_t y;
-  Point(int32_t __x, int32_t __y) : x(__x), y(__y) {}
-};
 
 struct leviathan_config {
   // Fan/pump profile
-  TempSource                      temp_source_{TempSource::CPU};
+  TempSource                      temp_source_{TempSource::Liquid};
   std::map<int32_t, LineFunction> fan_profile_;
   std::map<int32_t, LineFunction> pump_profile_;
 
@@ -35,9 +26,8 @@ struct leviathan_config {
   uint32_t main_color_{DEFAULT_RED};
 
   // Interval settings
-  uint32_t interval_{500};
+  uint32_t program_loop_interval_ms_{5000};
 };
 
 leviathan_config parse_config_file(const char *const path);
-
-#endif  // LEVIATHAN_CONFIG_H
+}  // namespace levd

--- a/leviathan_service.hpp
+++ b/leviathan_service.hpp
@@ -1,9 +1,7 @@
-#ifndef LEVIATHAN_SERVICE_H
-#define LEVIATHAN_SERVICE_H
-
+#pragma once
 #include <libusb-1.0/libusb.h>
 
+namespace levd {
 libusb_device *leviathan_init(libusb_device **devices, ssize_t num_devices);
-void leviathan_start(libusb_device *kraken_device);
-
-#endif  // LEVIATHAN_SERVICE_H
+void           leviathan_start(libusb_device *kraken_device);
+}  // namespace levd

--- a/main.cpp
+++ b/main.cpp
@@ -7,7 +7,7 @@ int main(int argc, char *argv[]) {
   FLAGS_logtostderr = 1;
   google::InstallFailureSignalHandler();
   google::InitGoogleLogging(argv[0]);
-  LOG(INFO) << "Starting Levd Daemon version: " << LEVD_VERSION_MAJOR << "."
+  SYSLOG(INFO) << "Starting Levd Daemon version: " << LEVD_VERSION_MAJOR << "."
             << LEVD_VERSION_MINOR;
 
   const int rc = libusb_init(NULL);
@@ -16,21 +16,21 @@ int main(int argc, char *argv[]) {
   libusb_device **devices;
   ssize_t         num_devices = libusb_get_device_list(NULL, &devices);
   if (num_devices == 0) {
-    LOG(WARNING) << "There are no usb devices attached";
+    SYSLOG(WARNING) << "There are no usb devices attached";
     return 0;
   }
-  LOG(INFO) << "libusb successfully initialized...";
-  LOG(INFO) << "There are " << num_devices << " usb devices hooked up";
-  libusb_device *kraken_device = leviathan_init(devices, num_devices);
+  SYSLOG(INFO) << "libusb successfully initialized...";
+  SYSLOG(INFO) << "There are " << num_devices << " usb devices hooked up";
+  libusb_device *kraken_device = levd::leviathan_init(devices, num_devices);
   if (kraken_device) {
-    LOG(INFO) << "Kraken X61 is detected";
-    LOG(INFO) << "Starting levd service...";
-    leviathan_start(kraken_device);
+    SYSLOG(INFO) << "Kraken X61 is detected";
+    SYSLOG(INFO) << "Starting levd service...";
+    levd::leviathan_start(kraken_device);
   } else {
-    LOG(ERROR) << "Kraken X61 was not detected";
+    SYSLOG(ERROR) << "Kraken X61 was not detected";
   }
 
-  LOG(INFO) << "... driver gracefully shutting down";
+  SYSLOG(INFO) << "... driver gracefully shutting down";
   libusb_free_device_list(devices, true);
   libusb_exit(NULL);
   return 0;

--- a/usb_descriptor_utils.hpp
+++ b/usb_descriptor_utils.hpp
@@ -1,21 +1,23 @@
+#pragma once
 #include <libusb-1.0/libusb.h>
 #include <string>
 
 #include "constants.h"
 
+namespace levd {
 bool incoming_endpoint(const libusb_endpoint_descriptor &endpoint);
 
-std::string get_serial_number(libusb_device_descriptor desc,
-                              libusb_device_handle *   handle);
-libusb_device_descriptor get_descriptor(libusb_device *device);
-libusb_device_handle *get_handle(libusb_device *device);
-libusb_config_descriptor *get_config_descriptor(libusb_device *device);
+std::string                 get_serial_number(libusb_device_descriptor desc,
+                                              libusb_device_handle *   handle);
+libusb_device_descriptor    get_descriptor(libusb_device *device);
+libusb_device_handle *      get_handle(libusb_device *device);
+libusb_config_descriptor *  get_config_descriptor(libusb_device *device);
 libusb_interface_descriptor get_main_usb_interface(
   libusb_config_descriptor *config);
 
 void set_endpoints(const libusb_endpoint_descriptor *endpoints,
-                   libusb_endpoint_descriptor &endpointIn,
-                   libusb_endpoint_descriptor &endpointOut);
+                   libusb_endpoint_descriptor &      endpointIn,
+                   libusb_endpoint_descriptor &      endpointOut);
 
 bool transfer_bulk_raw_data(libusb_device_handle *handle,
                             unsigned char         endpoint,
@@ -23,3 +25,4 @@ bool transfer_bulk_raw_data(libusb_device_handle *handle,
                             size_t                length);
 
 bool transfer_control_value(libusb_device_handle *handle, uint16_t value);
+}  // namespace levd


### PR DESCRIPTION
- Remove ifdef guard in favor or #pragma once
- Set namespace of levd { }
- New default value of 'temperature_source' set to liquid instead of cpu
- 'inteval' modified to 'program_loop_interval_ms'
- New 'fan_profile' defaults and 'program_loop_interval_ms' default values
- Switched logging output to SYSLOG like daemons should
- New debug parameter, averageTempAcrossCores()
- Removed odd delete [] for a variable which wasn't allocated as an array